### PR TITLE
Fix the name to spring-boot

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,6 +13,6 @@ $ brew tap spring-io/tap
 Now you will be able to work with Spring products as if there were in canonical Homebrew repository:
 
 ----
-$ brew install springboot
+$ brew install spring-boot
 ----
 


### PR DESCRIPTION
This change was not applied to the README, so I fixed it.
https://github.com/spring-io/homebrew-tap/commit/b4b65a8cc6f5a40602416d39462eaf5d01089983
