### PR TITLE
fix minor typo in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,6 +13,6 @@ $ brew tap spring-io/tap
 Now you will be able to work with Spring products as if there were in canonical Homebrew repository:
 
 ----
-$ brew install springboot
+$ brew install spring-boot
 ----
 


### PR DESCRIPTION
the formula is "spring-boot", with a dash
not "springboot"

no functional edits