### PR TITLE
spring-boot: install CLI jars into libexec and wrap binary

### DIFF
--- a/spring-boot.rb
+++ b/spring-boot.rb
@@ -16,9 +16,14 @@ class SpringBoot < Formula
       root = '.'
     end
 
-    bin.install Dir["#{root}/bin/spring"]
-    lib.install Dir["#{root}/lib/spring-boot-cli-*.jar"]
-    bash_completion.install Dir["#{root}/shell-completion/bash/spring"]
-    zsh_completion.install Dir["#{root}/shell-completion/zsh/_spring"]
+    libexec.install Dir["#{root}/*"]
+
+    (bin/"spring").write_env_script libexec/"bin/spring", {}
+
+    bash_comp = libexec/"shell-completion/bash/spring"
+    zsh_comp  = libexec/"shell-completion/zsh/_spring"
+
+    bash_completion.install bash_comp if bash_comp.exist?
+    zsh_completion.install  zsh_comp  if zsh_comp.exist?
   end
 end


### PR DESCRIPTION
### Summary
This PR updates the `spring-boot.rb` formula to install CLI jars into `libexec` instead of `lib`, and creates a wrapper script in `bin/spring`.

### Motivation
Installing JARs to `lib` is discouraged by Homebrew since it can cause conflicts between packages.  
The recommended approach is to use `libexec` and symlink or wrap binaries into `bin`.  

This change removes the following warning when installing with `HOMEBREW_DEVELOPER=true`:

Additionally, the completion installation was adjusted to avoid spurious warnings when completion scripts are not present in the distribution tarball.

### Related Issue
Fixes spring-projects/spring-boot#46866

### How to test
1. Run `brew install --build-from-source spring-boot.rb` with `HOMEBREW_DEVELOPER=true`.  
2. No warnings should be displayed.  
3. `spring --version` should print the CLI version correctly.